### PR TITLE
feat: add ColorStack LUM sponsor card with Instagram link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Welcome to the official repository for **HackHounds 2025**, Loyola University Ma
       - [MIS](#mis)
       - [CyberHounds](#cyberhounds)
       - [ACM](#acm)
+      - [ColorStack LUM](#colorstack-lum)
   - [Contributing](#contributing)
       - [Steps to Contribute](#steps-to-contribute)
   - [Contact](#contact)
@@ -164,6 +165,9 @@ We are grateful to our sponsors for their support:
 
 #### ACM
 - **Instagram**: [@loyolacomputes](https://www.instagram.com/loyolacomputes)
+
+#### ColorStack LUM
+- **Instagram**: [@colorstacklum](https://www.instagram.com/colorstacklum)
 
 ---
 


### PR DESCRIPTION

## Add ColorStack LUM Sponsor Card

I added a new sponsor card for **ColorStack LUM** to the sponsor section.  
It has our logo, a custom green title (`#00B555`), and a link to our Instagram page.

This card was styled consistently with the other sponsor cards.

---

>[!NOTE]
>As a representative of ColorStack LUM, I added this card to highlight our club’s involvement in HackHounds 2025.
